### PR TITLE
Add run scripts for double-click launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ and their tasks.
 
 ## Usage
 
+You can run the control panel by double-clicking the provided script for your
+platform:
+
+- **Windows:** `run_gui.bat`
+- **Linux/macOS:** `run_gui.sh`
+
+You can also launch it from a terminal:
+
 ```bash
 python gui.py
 ```

--- a/run_gui.bat
+++ b/run_gui.bat
@@ -1,0 +1,3 @@
+@echo off
+python "%~dp0gui.py"
+pause

--- a/run_gui.sh
+++ b/run_gui.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python3 "$(dirname "$0")/gui.py"


### PR DESCRIPTION
## Summary
- Add Windows and Unix launch scripts to run the GUI by double-click
- Document new double-click launch options in README

## Testing
- `python -m py_compile gui.py agent.py`
- `./run_gui.sh` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a61bcb8a148333bb4e47e1d0610268