### PR TITLE
feat: add agents and settings tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 This project provides a Tkinter-based control panel to manage simple AI agents
 and their tasks.
 
+The interface includes tabs for managing agents and application settings:
+
+- **Agents** – create or delete agents, set a prompt for their behavior, and
+  choose between cloud (OpenAI API) or local (Ollama) execution.
+- **Settings** – enter and persist an OpenAI API key and configure the port used
+  for a local Ollama instance.
+
 ## Usage
 
 You can run the control panel by double-clicking the provided script for your

--- a/agent.py
+++ b/agent.py
@@ -5,6 +5,8 @@ class AIAgent:
     """Simple representation of an AI agent."""
     name: str
     running: bool = False
+    prompt: str = ""
+    mode: str = "local"
 
     def start(self) -> None:
         """Mark the agent as running."""

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "openai_key": "",
+  "ollama_port": "11434"
+}


### PR DESCRIPTION
## Summary
- add prompt and mode fields to `AIAgent`
- introduce notebook UI with Agents and Settings tabs
- persist OpenAI API key and Ollama port in `config.json`

## Testing
- `python -m py_compile agent.py gui.py`
- `python gui.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a61e3cb8f883338261830738bdd229