### PR TITLE
feat: enhance agent and task management

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 class AIAgent:
     """Simple representation of an AI agent."""
     name: str
+    role: str = ""
     running: bool = False
     prompt: str = ""
     mode: str = "local"

--- a/agents.json
+++ b/agents.json
@@ -1,12 +1,14 @@
 [
   {
     "name": "Researcher-1",
+    "role": "",
     "running": false,
     "prompt": "",
     "mode": "local"
   },
   {
     "name": "Researcher-2",
+    "role": "",
     "running": false,
     "prompt": "",
     "mode": "local"


### PR DESCRIPTION
## Summary
- add roles to agents and expose role field in agent settings
- rename main tab to task list and support task deletion and column sorting
- add tooltip hints and API key paste button

## Testing
- `python -m py_compile agent.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a639a3c83c8333b592d1709ec3e322