### PR TITLE
Run Ollama start/stop asynchronously

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -468,60 +468,84 @@ class ControlPanel:
         self.status_var.set("Настройки сохранены")
         messagebox.showinfo("Настройки", "Настройки сохранены")
 
+    def append_ollama_log(self, text: str) -> None:
+        """Append a line from the Ollama process to the log output."""
+        print(text)
+
     def start_ollama(self) -> None:
         """Launch the Ollama server using a helper script and wait for readiness."""
         port = self.ollama_port_var.get().strip() or "11434"
         script = "run_ollama.bat" if os.name == "nt" else "run_ollama.sh"
         path = Path(__file__).with_name(script)
         self.status_var.set("Запуск Ollama...")
-        try:
-            if os.name == "nt":
-                proc = subprocess.run(["cmd", "/c", str(path), port], capture_output=True, text=True)
-            else:
-                proc = subprocess.run([str(path), port], capture_output=True, text=True)
-            if proc.returncode != 0:
-                msg = proc.stderr.strip() or proc.stdout.strip() or "Неизвестная ошибка"
-                self.status_var.set("Ошибка запуска Ollama")
-                messagebox.showerror("Ollama", f"Не удалось запустить сервер: {msg}")
-                return
-            self.status_var.set("Ollama сервер запускается")
 
-            def _wait_ready() -> None:
-                url = f"http://127.0.0.1:{port}/"
-                for _ in range(20):
-                    try:
-                        with urllib.request.urlopen(url, timeout=1):
-                            self.status_var.set("Ollama сервер запущен")
-                            self.master.after(0, lambda: messagebox.showinfo("Ollama", "Сервер Ollama запущен"))
-                            return
-                    except Exception:
-                        time.sleep(0.5)
-                self.status_var.set("Ollama не отвечает")
-                self.master.after(0, lambda: messagebox.showerror("Ollama", "Сервер Ollama не ответил"))
+        def _run() -> None:
+            try:
+                if os.name == "nt":
+                    proc = subprocess.Popen(["cmd", "/c", str(path), port], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                else:
+                    proc = subprocess.Popen([str(path), port], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                output: list[str] = []
+                if proc.stdout:
+                    for line in proc.stdout:
+                        output.append(line)
+                        self.master.after(0, lambda line=line: self.append_ollama_log(line.rstrip()))
+                ret = proc.wait()
+                if ret != 0:
+                    msg = "".join(output).strip() or "Неизвестная ошибка"
+                    self.master.after(0, lambda: self.status_var.set("Ошибка запуска Ollama"))
+                    self.master.after(0, lambda: messagebox.showerror("Ollama", f"Не удалось запустить сервер: {msg}"))
+                    return
+                self.master.after(0, lambda: self.status_var.set("Ollama сервер запускается"))
 
-            threading.Thread(target=_wait_ready, daemon=True).start()
-        except Exception as exc:
-            self.status_var.set("Ошибка запуска Ollama")
-            messagebox.showerror("Ollama", f"Не удалось запустить сервер: {exc}")
+                def _wait_ready() -> None:
+                    url = f"http://127.0.0.1:{port}/"
+                    for _ in range(20):
+                        try:
+                            with urllib.request.urlopen(url, timeout=1):
+                                self.master.after(0, lambda: self.status_var.set("Ollama сервер запущен"))
+                                self.master.after(0, lambda: messagebox.showinfo("Ollama", "Сервер Ollama запущен"))
+                                return
+                        except Exception:
+                            time.sleep(0.5)
+                    self.master.after(0, lambda: self.status_var.set("Ollama не отвечает"))
+                    self.master.after(0, lambda: messagebox.showerror("Ollama", "Сервер Ollama не ответил"))
+
+                threading.Thread(target=_wait_ready, daemon=True).start()
+            except Exception as exc:
+                self.master.after(0, lambda: self.status_var.set("Ошибка запуска Ollama"))
+                self.master.after(0, lambda: messagebox.showerror("Ollama", f"Не удалось запустить сервер: {exc}"))
+
+        threading.Thread(target=_run, daemon=True).start()
 
     def stop_ollama(self) -> None:
         """Stop the Ollama server process."""
         self.status_var.set("Остановка Ollama...")
-        try:
-            if os.name == "nt":
-                proc = subprocess.run(["taskkill", "/f", "/im", "ollama.exe"], capture_output=True, text=True)
-            else:
-                proc = subprocess.run(["pkill", "-f", "ollama serve"], capture_output=True, text=True)
-            if proc.returncode != 0:
-                msg = proc.stderr.strip() or proc.stdout.strip() or "Неизвестная ошибка"
-                self.status_var.set("Ошибка остановки Ollama")
-                messagebox.showerror("Ollama", f"Не удалось остановить сервер: {msg}")
-                return
-            self.status_var.set("Ollama сервер остановлен")
-            messagebox.showinfo("Ollama", "Сервер Ollama остановлен")
-        except Exception as exc:
-            self.status_var.set("Ошибка остановки Ollama")
-            messagebox.showerror("Ollama", f"Не удалось остановить сервер: {exc}")
+
+        def _run() -> None:
+            try:
+                if os.name == "nt":
+                    proc = subprocess.Popen(["taskkill", "/f", "/im", "ollama.exe"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                else:
+                    proc = subprocess.Popen(["pkill", "-f", "ollama serve"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                output: list[str] = []
+                if proc.stdout:
+                    for line in proc.stdout:
+                        output.append(line)
+                        self.master.after(0, lambda line=line: self.append_ollama_log(line.rstrip()))
+                ret = proc.wait()
+                if ret != 0:
+                    msg = "".join(output).strip() or "Неизвестная ошибка"
+                    self.master.after(0, lambda: self.status_var.set("Ошибка остановки Ollama"))
+                    self.master.after(0, lambda: messagebox.showerror("Ollama", f"Не удалось остановить сервер: {msg}"))
+                    return
+                self.master.after(0, lambda: self.status_var.set("Ollama сервер остановлен"))
+                self.master.after(0, lambda: messagebox.showinfo("Ollama", "Сервер Ollama остановлен"))
+            except Exception as exc:
+                self.master.after(0, lambda: self.status_var.set("Ошибка остановки Ollama"))
+                self.master.after(0, lambda: messagebox.showerror("Ollama", f"Не удалось остановить сервер: {exc}"))
+
+        threading.Thread(target=_run, daemon=True).start()
 
     def delete_key(self) -> None:
         if not messagebox.askyesno("Удалить ключ", "Удалить API ключ?"):


### PR DESCRIPTION
## Summary
- Launch and stop Ollama in background threads, piping output to `append_ollama_log`
- Update readiness checks and status updates to use Tkinter's `after` to avoid threading issues

## Testing
- `python -m py_compile gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2277325088333964e51e4f799bcb0